### PR TITLE
Fixed deprecated std::env::home_dir -> dirs crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shellexpand"
-version = "1.0.1"
+version = "1.1.0"
 authors = ["Vladimir Matveev <vladimir.matweev@gmail.com>"]
 license = "MIT/Apache-2.0"
 description = "Shell-like expansions in strings"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,3 +9,6 @@ documentation = "http://netvl.github.io/shellexpand/"
 readme = "Readme.md"
 keywords = ["strings", "shell", "variables"]
 
+[dependencies]
+dirs = "1.0"
+

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shellexpand"
-version = "1.0.0"
+version = "1.0.1"
 authors = ["Vladimir Matveev <vladimir.matweev@gmail.com>"]
 license = "MIT/Apache-2.0"
 description = "Shell-like expansions in strings"

--- a/Readme.md
+++ b/Readme.md
@@ -22,7 +22,7 @@ Just add a dependency in your `Cargo.toml`:
 
 ```toml
 [dependencies]
-shellexpand = "1.0.1"
+shellexpand = "1.1.0"
 ```
 
 See the crate documentation (a link is present in the beginning of this readme) for more information

--- a/Readme.md
+++ b/Readme.md
@@ -8,13 +8,13 @@ shellexpand, a library for shell-like expansion in strings
 
 [Documentation](https://docs.rs/shellexpand/)
 
-shellexpand is a small dependency-less library which allows one to perform shell-like expansions in strings,
+shellexpand is a single dependency library which allows one to perform shell-like expansions in strings,
 that is, to expand variables like `$A` or `${B}` into their values inside some context and to expand
 `~` in the beginning of a string into the home directory (again, inside some context).
 
 This crate provides generic functions which accept arbitrary contexts as well as default, system-based
 functions which perform expansions using the system-wide context (represented by functions from `std::env`
-module).
+module and [dirs](https://crates.io/crates/dirs) crate).
 
 ## Usage
 
@@ -22,7 +22,7 @@ Just add a dependency in your `Cargo.toml`:
 
 ```toml
 [dependencies]
-shellexpand = "1.0"
+shellexpand = "1.0.1"
 ```
 
 See the crate documentation (a link is present in the beginning of this readme) for more information
@@ -30,6 +30,9 @@ and examples.
 
 
 ## Changelog
+
+### Version 1.0.1
+* Changed use of deprecated `std::env::home_dir` to the crate [dirs](https://crates.io/crates/dirs)::home_dir
 
 ### Version 1.0.0
 

--- a/Readme.md
+++ b/Readme.md
@@ -31,8 +31,9 @@ and examples.
 
 ## Changelog
 
-### Version 1.0.1
-* Changed use of deprecated `std::env::home_dir` to the crate [dirs](https://crates.io/crates/dirs)::home_dir
+### Version 1.1.0
+
+* Changed use of deprecated `std::env::home_dir` to the [dirs](https://crates.io/crates/dirs)::home_dir function
 
 ### Version 1.0.0
 


### PR DESCRIPTION
In Rust version 1.29.0 this function was deprecated in favor of the
crate dirs platform agnostic implementation. Refer to issue #3 

Updates:
* Readme documentation that references the use of std::env::home_dir
* Now states that the library has only one dependency
* Test cases that used std::env::home_dir explicitly
* Documentation that referenced std::env::home_dir
* Added dirs version 1.0 as a dependency in Cargo.toml

I suggest a version bump to 1.0.1 in order to make this library available on crates.io

Pretty sure I, unintentionally, ran the project through rustfmt :+1: