### PR TITLE
Bump dirs dependency to 2.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,5 +10,5 @@ readme = "Readme.md"
 keywords = ["strings", "shell", "variables"]
 
 [dependencies]
-dirs = "1.0"
+dirs = "2.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shellexpand"
-version = "1.1.0"
+version = "1.1.1"
 authors = ["Vladimir Matveev <vladimir.matweev@gmail.com>"]
 license = "MIT/Apache-2.0"
 description = "Shell-like expansions in strings"

--- a/Readme.md
+++ b/Readme.md
@@ -22,7 +22,7 @@ Just add a dependency in your `Cargo.toml`:
 
 ```toml
 [dependencies]
-shellexpand = "1.1.0"
+shellexpand = "1.1.1"
 ```
 
 See the crate documentation (a link is present in the beginning of this readme) for more information
@@ -30,6 +30,10 @@ and examples.
 
 
 ## Changelog
+
+### Version 1.1.1
+
+* Bump `dirs` dependency to 2.0.
 
 ### Version 1.1.0
 


### PR DESCRIPTION
This PR bumps the dependency of the `dirs` crate to 2.0 and is a followup from GH-4.

Depending on `dirs` 2.0 line brings the latest `dirs-sys` dependency and some fixes to config dir handling on Linux. This upgrade required no code changes.

I also included a commit to bump the version of this crate because I'm hoping this PR can be released as a patch version.

Thank you.