### PR TITLE
Switches from `dirs` to `dirs-next`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,5 +10,4 @@ readme = "Readme.md"
 keywords = ["strings", "shell", "variables"]
 
 [dependencies]
-dirs = "2.0"
-
+dirs-next = "2.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -88,7 +88,7 @@
 //! The above example also demonstrates the flexibility of context function signatures: the context
 //! function may return anything which can be `AsRef`ed into a string slice.
 
-extern crate dirs;
+extern crate dirs_next as dirs;
 
 use std::borrow::Cow;
 use std::env::VarError;
@@ -272,7 +272,7 @@ where
 /// # Examples
 ///
 /// ```
-/// extern crate dirs;
+/// extern crate dirs_next as dirs;
 /// use std::env;
 ///
 /// env::set_var("A", "a value");
@@ -697,7 +697,7 @@ where
 /// # Examples
 ///
 /// ```
-/// extern crate dirs;
+/// extern crate dirs_next as dirs;
 ///
 /// let hds = dirs::home_dir()
 ///     .map(|p| p.display().to_string())


### PR DESCRIPTION
The crate `dirs` is no longer maintained. `dirs-next` is a maintained
fork of the crate.
