### PR TITLE
Apply clippy suggestions

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -669,11 +669,7 @@ where
     HD: FnOnce() -> Option<P>,
 {
     let input_str = input.as_ref();
-    if input_str.starts_with("~") {
-        let input_after_tilde = match input_str.strip_prefix("~") {
-            Some(v) => v,
-            None => return input_str.into()
-        };
+    if let Some(input_after_tilde) = input_str.strip_prefix("~") {
         if input_after_tilde.is_empty() || input_after_tilde.starts_with("/") {
             if let Some(hd) = home_dir() {
                 let result = format!("{}{}", hd.as_ref().display(), input_after_tilde);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -670,7 +670,10 @@ where
 {
     let input_str = input.as_ref();
     if input_str.starts_with("~") {
-        let input_after_tilde = &input_str[1..];
+        let input_after_tilde = match input_str.strip_prefix("~") {
+            Some(v) => v,
+            None => return input_str.into()
+        };
         if input_after_tilde.is_empty() || input_after_tilde.starts_with("/") {
             if let Some(hd) = home_dir() {
                 let result = format!("{}{}", hd.as_ref().display(), input_after_tilde);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -181,12 +181,10 @@ where
             if !input.as_ref().starts_with("~") && s.starts_with("~") {
                 // return as is
                 s.into()
+            } else if let Cow::Owned(s) = tilde_with_context(&s, home_dir) {
+                s.into()
             } else {
-                if let Cow::Owned(s) = tilde_with_context(&s, home_dir) {
-                    s.into()
-                } else {
-                    s.into()
-                }
+                s.into()
             }
         }
     })

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -178,7 +178,7 @@ where
         Cow::Owned(s) => {
             // if the original string does not start with a tilde but the processed one does,
             // then the tilde is contained in one of variables and should not be expanded
-            if !input.as_ref().starts_with("~") && s.starts_with("~") {
+            if !input.as_ref().starts_with('~') && s.starts_with('~') {
                 // return as is
                 s.into()
             } else if let Cow::Owned(s) = tilde_with_context(&s, home_dir) {
@@ -524,7 +524,7 @@ where
                     }
                 }
             } else {
-                result.push_str("$");
+                result.push('$');
                 input_str = if next_char == Some('$') {
                     &input_str[2..] // skip the next dollar for escaping
                 } else {
@@ -667,8 +667,8 @@ where
     HD: FnOnce() -> Option<P>,
 {
     let input_str = input.as_ref();
-    if let Some(input_after_tilde) = input_str.strip_prefix("~") {
-        if input_after_tilde.is_empty() || input_after_tilde.starts_with("/") {
+    if let Some(input_after_tilde) = input_str.strip_prefix('~') {
+        if input_after_tilde.is_empty() || input_after_tilde.starts_with('/') {
             if let Some(hd) = home_dir() {
                 let result = format!("{}{}", hd.as_ref().display(), input_after_tilde);
                 result.into()


### PR DESCRIPTION
This PR applies clippy suggestions that were provided by `cargo clippy` on clippy version `0.1.59`

Things done:
- change `else { if }` to `else if`
- change to not manually strip the prefix (could panic if not stripping on a character boundary, but should not matter in this case because of the first check with `starts_with`)
- change to just use `strip_prefix` instead of `starts_with { strip_prefix }` (deduplicate, should increase performance)
- change single character things to use char (should increase performance slightly)